### PR TITLE
Front 20 Add repository search and sorting

### DIFF
--- a/frontend/src/MainBlock/Artifacts/Artifacts.js
+++ b/frontend/src/MainBlock/Artifacts/Artifacts.js
@@ -12,7 +12,9 @@ import { fetchArtifactTree } from 'redux/models/Artifact/artifactsActions';
 import { genericPaper } from 'Utils/commonStyles';
 import ArtifactRepositoryItem from './ArtifactRepositoryItem';
 
-const styles = genericPaper;
+const styles = () => ({
+    genericPaper,
+});
 
 function Artifacts({ classes, artifactTree, fetchArtifactTree }) {
     useEffect(() => {
@@ -20,7 +22,7 @@ function Artifacts({ classes, artifactTree, fetchArtifactTree }) {
     }, []);
 
     return (
-        <Paper className={classes.root}>
+        <Paper className={classes.genericPaper}>
             <Typography variant="h4">
                 Artifacts
                 {!artifactTree && ' not found'}

--- a/frontend/src/MainBlock/Pagination/PaginationWidget.js
+++ b/frontend/src/MainBlock/Pagination/PaginationWidget.js
@@ -6,15 +6,11 @@ import MenuItem from '@material-ui/core/MenuItem';
 import Select from '@material-ui/core/Select';
 
 import { PER_PAGE_VARIANTS } from 'Utils/constants';
-import { secondaryItemColor } from 'Utils/commonStyles';
+import { secondaryItemColor, flexInlineContainer } from 'Utils/commonStyles';
 import PaginationButton from './PaginationButton';
 
 const styles = () => ({
-    widgetContainer: {
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-    },
+    widgetContainer: flexInlineContainer,
     perPageLabel: {
         padding: '18px',
         color: secondaryItemColor,

--- a/frontend/src/MainBlock/Repositories/FetchingParams/FetchingParams.js
+++ b/frontend/src/MainBlock/Repositories/FetchingParams/FetchingParams.js
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+
+import { withStyles } from '@material-ui/core/styles';
+import TextField from '@material-ui/core/TextField';
+import Badge from '@material-ui/core/Badge';
+import IconButton from '@material-ui/core/IconButton';
+import SortIcon from '@material-ui/icons/Sort';
+import Menu from '@material-ui/core/Menu';
+
+import connect from 'react-redux/es/connect/connect';
+import SortingAttributes from './SortingAttributes';
+
+const styles = () => ({
+    repositoriesSearchInput: {
+        width: '300px',
+        marginBottom: '10px',
+    },
+});
+
+function FetchingParams({ classes, searchString, handleSearchStringChange, handleOrderParamsChange,
+    sortAttributes, setSortAttributes }) {
+    const [anchorEl, setAnchorEl] = useState(null);
+
+    const handleSortButtonClick = (event) => {
+        setAnchorEl(event.currentTarget);
+    };
+
+    const handleSortMenuClose = () => {
+        handleOrderParamsChange();
+        setAnchorEl(null);
+    };
+
+    return (
+        <div>
+            <TextField
+                className={classes.repositoriesSearchInput}
+                label="Search repository"
+                value={searchString}
+                onChange={handleSearchStringChange}
+                type="search"
+            />
+            <IconButton onClick={handleSortButtonClick}>
+                <Badge badgeContent={sortAttributes.length} color="primary">
+                    <SortIcon />
+                </Badge>
+            </IconButton>
+            <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleSortMenuClose}>
+                <SortingAttributes
+                    sortedAttributes={sortAttributes}
+                    setSortedAttributes={setSortAttributes}
+                />
+            </Menu>
+        </div>
+    );
+}
+
+FetchingParams.propTypes = {
+    classes: PropTypes.object.isRequired,
+    searchString: PropTypes.string.isRequired,
+    handleSearchStringChange: PropTypes.func.isRequired,
+    handleOrderParamsChange: PropTypes.func.isRequired,
+    sortAttributes: PropTypes.array.isRequired,
+    setSortAttributes: PropTypes.func.isRequired,
+};
+
+export default connect(
+    state => ({ searchString: state.repositories.searchString }),
+)(withStyles(styles)(FetchingParams));

--- a/frontend/src/MainBlock/Repositories/FetchingParams/SortingAttribute.js
+++ b/frontend/src/MainBlock/Repositories/FetchingParams/SortingAttribute.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+import { withStyles } from '@material-ui/core/styles';
+import MenuItem from '@material-ui/core/MenuItem';
+import ListItemText from '@material-ui/core/ListItemText';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ArrowIcon from '@material-ui/icons/KeyboardBackspace';
+
+const styles = theme => ({
+    activeAttributeItem: {
+        color: theme.palette.primary.main,
+    },
+    attributeItem: {
+        width: '200px',
+        '&:hover': {
+            color: theme.palette.primary.main,
+        },
+    },
+    icon: {
+        color: theme.palette.primary.main,
+        marginRight: '0px',
+    },
+    iconUp: {
+        transform: 'rotate(90deg)',
+    },
+    iconDown: {
+        transform: 'rotate(270deg)',
+    },
+});
+
+function SortingAttribute({ classes, name, label, state, handleClick }) {
+    const onClick = () => handleClick(name);
+
+    return (
+        <MenuItem
+            onClick={onClick}
+            className={classNames(classes.attributeItem, { [classes.activeAttributeItem]: state })}
+        >
+            <ListItemText>{label}</ListItemText>
+            {state && (
+                <ListItemIcon className={classNames(classes.icon, state === 'asc' ? classes.iconUp : classes.iconDown)}>
+                    <ArrowIcon />
+                </ListItemIcon>
+            )}
+        </MenuItem>
+    );
+}
+
+SortingAttribute.propTypes = {
+    classes: PropTypes.object.isRequired,
+    name: PropTypes.string.isRequired,
+    label: PropTypes.string.isRequired,
+    state: PropTypes.string,
+    handleClick: PropTypes.func.isRequired,
+};
+
+export default withStyles(styles)(SortingAttribute);

--- a/frontend/src/MainBlock/Repositories/FetchingParams/SortingAttributes.js
+++ b/frontend/src/MainBlock/Repositories/FetchingParams/SortingAttributes.js
@@ -1,0 +1,90 @@
+import React, { Fragment, useState } from 'react';
+import PropTypes from 'prop-types';
+
+import SortingAttribute from './SortingAttribute';
+
+const availableAttributes = {
+    name: {
+        label: 'Repository name',
+        state: null,
+    },
+    createdAt: {
+        label: 'Creating date',
+        state: null,
+    },
+    updatedAt: {
+        label: 'Updating date',
+        state: null,
+    },
+    repositoryType: {
+        label: 'Repository type',
+        state: null,
+    },
+};
+
+const availableStates = [null, 'asc', 'desc'];
+
+const getNextState = currentState => availableStates[
+    (availableStates.indexOf(currentState) + 1) % availableStates.length
+];
+
+function SortingAttributes({ sortedAttributes, setSortedAttributes }) {
+    const [sortAttributes, setSortAttributes] = useState(availableAttributes);
+
+    const getAttribute = attributeName => ({
+        name: attributeName,
+        label: sortAttributes[attributeName].label,
+        state: sortAttributes[attributeName].state,
+    });
+
+    const rebuildSortOrder = (attributeName, newState) => {
+        const attributeSortIndex = sortedAttributes.findIndex(item => item.name === attributeName);
+        const newSortOrder = [...sortedAttributes];
+
+        if (newState && attributeSortIndex === -1) {
+            newSortOrder.push(getAttribute(attributeName));
+        }
+
+        if (attributeSortIndex !== -1) {
+            if (newState) {
+                newSortOrder[attributeSortIndex] = getAttribute(attributeName);
+            } else {
+                newSortOrder.splice(attributeSortIndex, 1);
+            }
+        }
+
+        setSortedAttributes(newSortOrder);
+    };
+
+    const handleClick = (attributeName) => {
+        if (!sortAttributes[attributeName]) {
+            return;
+        }
+        const newState = getNextState(sortAttributes[attributeName].state);
+        const changedAttributes = Object.assign({}, sortAttributes);
+        changedAttributes[attributeName].state = newState;
+        setSortAttributes(changedAttributes);
+        rebuildSortOrder(attributeName, newState);
+    };
+
+    return (
+        <Fragment>
+            {Object.keys(sortAttributes).map(name => (
+                <SortingAttribute
+                    key={name}
+                    name={name}
+                    label={sortAttributes[name].label}
+                    state={sortAttributes[name].state}
+                    handleClick={handleClick}
+                />
+            ))}
+        </Fragment>
+    );
+}
+
+SortingAttributes.propTypes = {
+    sortedAttributes: PropTypes.array.isRequired,
+    setSortedAttributes: PropTypes.func.isRequired,
+};
+
+export default SortingAttributes;

--- a/frontend/src/Utils/commonStyles.js
+++ b/frontend/src/Utils/commonStyles.js
@@ -188,6 +188,12 @@ export const repoIconsContainer = {
     alignItems: 'flex-end',
 };
 
+export const flexInlineContainer = {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+};
+
 export const capitalize = {
     display: 'block',
     textTransform: 'lowercase',
@@ -201,9 +207,7 @@ export const linkControlIcon = {
 };
 
 export const linkFormHeader = {
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'center',
+    ...flexInlineContainer,
     paddingRight: '20px',
 };
 
@@ -224,9 +228,7 @@ export const listItemWithoutIcon = {
     marginLeft: '60px',
 };
 
-export const genericPaper = theme => ({
-    root: {
-        padding: `${theme.spacing.unit}px ${theme.spacing.unit * 2}px`,
-        width: `${theme.spacing.unit * 100}px`,
-    },
-});
+export const genericPaper = {
+    padding: '16px',
+    width: '800px',
+};

--- a/frontend/src/Utils/constants.js
+++ b/frontend/src/Utils/constants.js
@@ -4,3 +4,4 @@ export const RELATION_URL = `${BASE_URL}relations/`;
 export const REPOSITORY_LINK_URL = `${BASE_URL}repository-link/`;
 export const PER_PAGE_VARIANTS = [10, 15, 20, 30, 50, 80, 120];
 export const DEFAULT_PER_PAGE_VARIANT = 1;
+export const SEARCH_REQUEST_THRESHOLD = 400;

--- a/frontend/src/redux/models/Repository/repositoriesActions.js
+++ b/frontend/src/redux/models/Repository/repositoriesActions.js
@@ -11,6 +11,7 @@ export const ADD_LINK = 'ADD_LINK';
 export const EDIT_LINK = 'EDIT_LINK';
 export const DELETE_LINK = 'DELETE_LINK';
 export const SET_FORM_RESULT = 'SET_FORM_RESULT';
+export const SET_SEARCH_STRING = 'SET_SEARCH_STRING';
 
 export const fetchRepositoriesAction = repositories => ({
     type: FETCH_REPOSITORIES,
@@ -69,6 +70,11 @@ export const deleteLinkAction = (repositoryId, linkId) => ({
     },
 });
 
+export const setSearchStringAction = searchString => ({
+    type: SET_SEARCH_STRING,
+    payload: searchString,
+});
+
 export function fetchRepositories() {
     return (dispatch) => {
         axios.get(REPOSITORY_URL)
@@ -81,9 +87,14 @@ export function fetchRepositories() {
     };
 }
 
-export function fetchRepositoriesPage(page = 0, perPage) {
+export function fetchRepositoriesPage(perPage, searchString, orderAttributes, page = 0) {
     return (dispatch) => {
-        axios.get(`${REPOSITORY_URL}/page?page=${page}&perPage=${perPage}`)
+        const searchParam = searchString === '' ? searchString : `&searchString=${searchString}`;
+        let orderParams = '';
+        orderAttributes.forEach((attribute) => {
+            orderParams += `&order=${attribute.name},${attribute.state}`;
+        });
+        axios.get(`${REPOSITORY_URL}/page?page=${page}&perPage=${perPage}${searchParam}${orderParams}`)
             .then((response) => {
                 dispatch(fetchRepositoriesPageAction(page, response.data));
             })
@@ -164,5 +175,11 @@ export function deleteLink(repositoryLinkId, repositoryId) {
                 dispatch(setFormResultAction(true, 'Link', 'deleted'));
             })
             .catch(() => dispatch(setFormResultAction(false)));
+    };
+}
+
+export function setSearchString(searchString) {
+    return (dispatch) => {
+        dispatch(setSearchStringAction(searchString));
     };
 }

--- a/frontend/src/redux/models/Repository/repositoriesReducer.js
+++ b/frontend/src/redux/models/Repository/repositoriesReducer.js
@@ -1,11 +1,12 @@
 import createReducer from 'redux/createReducer';
 import { FETCH_REPOSITORIES, FETCH_REPOSITORIES_PAGE, CLEAR_REPOSITORIES_PAGES, FETCH_REPOSITORY,
-    FETCH_LINK_TYPES, ADD_LINK, EDIT_LINK, DELETE_LINK } from './repositoriesActions';
+    FETCH_LINK_TYPES, ADD_LINK, EDIT_LINK, DELETE_LINK, SET_SEARCH_STRING } from './repositoriesActions';
 
 export const initialState = {
     list: {},
     pages: {},
     pageCount: undefined,
+    searchString: '',
     repositoryById: {},
     linkTypes: undefined,
 };
@@ -63,4 +64,5 @@ export const repositoriesReducer = createReducer(initialState, {
             .linkUrls.filter(item => (item.repositoryLinkId !== linkId));
         return newState;
     },
+    [SET_SEARCH_STRING]: (state, action) => ({ ...state, searchString: action.payload }),
 });


### PR DESCRIPTION
Добавлена строка поиска по имени репозитория и возможность сортировки по следующим полям: name, createdAt, updatedAt, repositoryType.
Порядок сортировки определяется порядком нажатия на поле с атрибутом сортировки. 
У каждого поля есть 3 состояния: 
1) не участвует в сортировке
2) сортировать по возрастанию
3) сортировать по убыванию
При нажатии на поле состояние переходит в следующее за текущим
<img width="1440" alt="Снимок экрана 2019-05-28 в 23 55 09" src="https://user-images.githubusercontent.com/18597504/58512688-62950b80-81a6-11e9-9e3f-645bb7d1c621.png">
<img width="1440" alt="Снимок экрана 2019-05-28 в 23 55 27" src="https://user-images.githubusercontent.com/18597504/58512694-64f76580-81a6-11e9-976f-34e3f96fe09d.png">
<img width="1440" alt="Снимок экрана 2019-05-28 в 23 55 41" src="https://user-images.githubusercontent.com/18597504/58512700-6759bf80-81a6-11e9-8a58-ee0814e72998.png">
<img width="1440" alt="Снимок экрана 2019-05-29 в 0 04 08" src="https://user-images.githubusercontent.com/18597504/58512712-6cb70a00-81a6-11e9-8729-fb978a45cc50.png">