### PR TITLE
front-24 add event info to repository on main page

### DIFF
--- a/frontend/src/MainBlock/Repositories/ListItemInfo.js
+++ b/frontend/src/MainBlock/Repositories/ListItemInfo.js
@@ -10,19 +10,25 @@ const useStyles = makeStyles({
     dateListItem,
 });
 
-export default function ListItemInfo({ descr, date }) {
+export default function ListItemInfo({ descr, dateUpdate, dateEvent }) {
     const classes = useStyles();
     return (
         <Fragment>
             {`${descr}`}
             <span className={classes.dateListItem}>
-                {`Updated ${formatDate(date)}`}
+                {`Updated ${formatDate(dateUpdate)}`}
             </span>
+            {dateEvent && (
+                <span className={classes.dateListItem}>
+                    {`Last event ${formatDate(dateEvent)}`}
+                </span>
+            )}
         </Fragment>
     );
 }
 
 ListItemInfo.propTypes = {
     descr: PropTypes.string.isRequired,
-    date: PropTypes.string.isRequired,
+    dateUpdate: PropTypes.string.isRequired,
+    dateEvent: PropTypes.string,
 };

--- a/frontend/src/MainBlock/Repositories/RepositoryItem.js
+++ b/frontend/src/MainBlock/Repositories/RepositoryItem.js
@@ -43,7 +43,8 @@ function RepositoryItem({ classes, repository }) {
                 secondary={(
                     <ListItemInfo
                         descr={repository.description === null ? '' : repository.description}
-                        date={repository.updatedAt}
+                        dateUpdate={repository.updatedAt}
+                        dateEvent={repository.lastEvent}
                     />
                 )}
             />


### PR DESCRIPTION
в рамках задачи добавил информацию о последнем событии к описанию репозитория на главной странице
![localhost_3000_repositories](https://user-images.githubusercontent.com/22192804/58765922-ec671f00-8580-11e9-9944-6026150d84a8.png)
